### PR TITLE
Added check for packets with heplify packet size set to 0 when receiving TCP packets.

### DIFF
--- a/server/tcp.go
+++ b/server/tcp.go
@@ -83,8 +83,9 @@ func (h *HEPInput) handleStream(c net.Conn, protocol string) {
 			return
 		} else {
 			size := binary.BigEndian.Uint16(hb[4:6])
-			if size > maxPktLen {
+			if size > maxPktLen || size == 0 {
 				logp.Warn("wrong or too big HEP packet size with %d bytes", size)
+				logp.Warn("hb: % x", hb)
 				//r.Reset(c)
 				//continue
 				return


### PR DESCRIPTION
This is an exceptional scenario, however port scanners which e.g. scan for X11 sessions, might send packets where byte 4:6 are set to 0x00.